### PR TITLE
Switch from Drakma to Dexador to avoid CL+SSL Windows dependency

### DIFF
--- a/tecgraf-libs.asd
+++ b/tecgraf-libs.asd
@@ -10,10 +10,8 @@
                (:file "tecgraf-libs"))
   :depends-on (#:trivial-features
                #:cl-fad
-               #:cl+ssl
-               #:drakma
-               #:cffi
-               #:puri
+               #:dexador
+               #:quri
                #+(or (and sbcl os-windows) (and ccl windows)) #:zip
                #+linux #:uiop
                #:ironclad)

--- a/tecgraf-libs/tecgraf-libs.lisp
+++ b/tecgraf-libs/tecgraf-libs.lisp
@@ -87,6 +87,8 @@
          (unpacked (unpack verified)))
     #+linux
     (patch unpacked)
+    #+windows
+    (declare (ignore unpacked))
     (format t "~&Unpacked to ~S~%" *libs-pathname*)
     (let ((path (asdf:system-relative-pathname "tecgraf-libs" "libs/")))
       (format t "

--- a/tecgraf-libs/utils.lisp
+++ b/tecgraf-libs/utils.lisp
@@ -4,15 +4,14 @@
 
 (defun pathname-from-url (url)
   "Given http://example.com/foo.zip, return #p\"foo.zip\"."
-  (path:basename (puri:uri-path (puri:parse-uri url))))
+  (path:basename (quri:uri-path (quri:uri url))))
 
 (defun download-to-pathname (url output-pathname)
   (with-open-file
       (output-stream output-pathname :direction :output :if-exists :supersede :element-type '(unsigned-byte 8))
     (multiple-value-bind
           (input-stream status-code)
-        ;; (drakma:http-request url :verify :required :want-stream t)
-      (drakma:http-request url :want-stream t)
+        (dex:get url :want-stream t :max-redirects 10)
       (if (= status-code 200)
           (loop with buffer
                   = (make-array +buffer-size+ :element-type '(unsigned-byte 8))


### PR DESCRIPTION
Makes life easier for Windows users.